### PR TITLE
Don't prompt to flip dead tiles (ones or voltorbs)

### DIFF
--- a/server/voltorbflip/psol_search.go
+++ b/server/voltorbflip/psol_search.go
@@ -93,7 +93,7 @@ func (psol vfPartialSolution) SafestUnsolvedPosition() (bool, bool, VfBoardPosit
 				return false, false, VfBoardPosition{}, 0
 			}
 			return psol.SafestUnsolvedPosition()
-		} else if safePossibilities > safestNumberOfPossibilities {
+		} else if (safePossibilities > safestNumberOfPossibilities) && psol.GetTile(position).IsPossiblyNecessaryToWin() {
 			safestPosition = position
 			safestNumberOfPossibilities = safePossibilities
 		}


### PR DESCRIPTION
As-is, the project greedily prompts you to flip the tile that has the lowest chance of being a voltorb (ie, losing).  The consequence of this is that it often asks you to flip tiles that can only either be 1 or Voltorb.  This is an unnecessary risk, since even if you get the tile "right" (ie, it's a 1), it doesn't usually get you any closer to solving the game.  

This PR ensures that the suggested tile can either possibly contain a 2 or 3, so you're only prompted on choosing tiles that get you closer to winning.

(N.B. I think you could contrive cases where the "optimal" play would be to try to flip the "dead tile" (1 or V) for information that makes future "live tiles" more in your favor.  This PR doesn't address that case, since in general this solver only has a lookahead of 1 flip - we're not trying to optimize the order you flip tiles to improve future odds. )