### PR TITLE
Fix broken images in console text boxes

### DIFF
--- a/jekyll-site/assets/style.css
+++ b/jekyll-site/assets/style.css
@@ -169,6 +169,10 @@ div.text div.spacing div.inner p {
   line-height: 1.2em;
 }
 
+div.text.console img {
+  vertical-align: -0.5em;
+}
+
 table.prizes {
   width: 90%;
   margin: 1em auto 1em auto;

--- a/jekyll-site/assets/vflip.js
+++ b/jekyll-site/assets/vflip.js
@@ -232,7 +232,7 @@ function ajaxSuccess(data) {
   updateBoardDisplay();
 
   if (data["IsWon"]) {
-    showMessage("win", "Game clear! You've found all the hidden <img src=\"https://s3.amazonaws.com/vflip/images/3.png\"> and <img src=\"https://s3.amazonaws.com/vflip/images/2.png\"> cards.");
+    showMessage("win", "Game clear! You've found all the hidden <img src=\"/assets/images/3.png\"> and <img src=\"/assets/images/2.png\"> cards.");
     return;
   }
 
@@ -284,7 +284,7 @@ function ajaxSuccess(data) {
     } else {
       safetyString = parseFloat(safety).toFixed(0);
     }
-    showMessage("warn", "What is this Card? There is a " + safetyString + "% chance it is a <img src=\"https://s3.amazonaws.com/vflip/images/volt.png\" />.");
+    showMessage("warn", "What is this Card? There is a " + safetyString + "% chance it is a <img src=\"/assets/images/volt.png\" />.");
   }
 }
 


### PR DESCRIPTION
This PR simply fixes some broken image URLs for the icons in the console texts. They are now absolute paths to `/assets/images` instead of being full HTTPS URLs. They are also now vertically centered.

Before:

![before](https://user-images.githubusercontent.com/43387454/192969867-87edf79d-e3d2-4e74-b719-9e742c405187.png)

After:

![after](https://user-images.githubusercontent.com/43387454/192969906-7acc5e65-38a8-46ff-b22a-7ba1862b6eb7.png)